### PR TITLE
Skip any number of header comment lines

### DIFF
--- a/FML/COLASolver/src/Simulation.h
+++ b/FML/COLASolver/src/Simulation.h
@@ -791,7 +791,7 @@ void NBodySimulation<NDIM, T>::init() {
         const int col_k = 0;
         const int col_pofk = 1;
         std::vector<int> cols_to_keep{col_k, col_pofk};
-        const int nheaderlines = 1;
+        const int nheaderlines = -1; // skip header comments
         auto pofkdata = FML::FILEUTILS::read_regular_ascii(ic_input_filename, ncols, cols_to_keep, nheaderlines);
 
         karr.resize(pofkdata.size());
@@ -838,7 +838,7 @@ void NBodySimulation<NDIM, T>::init() {
         const int col_k = 0;
         const int col_tofk = 1;
         std::vector<int> cols_to_keep{col_k, col_tofk};
-        const int nheaderlines = 1;
+        const int nheaderlines = -1; // skip header comments
         auto tofkdata = FML::FILEUTILS::read_regular_ascii(ic_input_filename, ncols, cols_to_keep, nheaderlines);
 
         karr.resize(tofkdata.size());

--- a/FML/FileUtils/FileUtils.cpp
+++ b/FML/FileUtils/FileUtils.cpp
@@ -11,6 +11,7 @@ namespace FML {
         // Read a regular ascii files with nskip header lines and containing ncol collums
         // nestimated_lines is the amount we allocate for originally. Reallocated if file is larger
         // Not perfect for realy large files due to all the allocations we have to do
+        // If nskip is negative, header lines starting with # are skipped
         DVector2D read_regular_ascii(std::string filename,
                                      int ncols,
                                      std::vector<int> cols_to_keep,
@@ -18,7 +19,7 @@ namespace FML {
                                      size_t nestimated_lines) {
 
             // Sanity check
-            assert(cols_to_keep.size() > 0 and nskip >= 0 and ncols > 0);
+            assert(cols_to_keep.size() > 0 and ncols > 0);
             for (auto & i : cols_to_keep)
                 assert(i < ncols and i >= 0);
 
@@ -37,8 +38,8 @@ namespace FML {
             DVector newline(ntokeep);
             DVector temp(ncols);
 
-            // Read and skip header lines
-            for (int i = 0; i < nskip; i++) {
+            // Read and skip header lines (fixed number or all lines starting with #)
+            for (int i = 0; i < nskip || (nskip < 0 && fp && fp.peek() == '#'); i++) {
                 std::string line;
                 std::getline(fp, line);
 #ifdef DEBUG_READASCII


### PR DESCRIPTION
Quick suggestion to generalize file reading to skip any number of header lines starting with `#` if `nskip < 0`.
The current format (and CAMB?) requires exactly 1 header line, but CLASS outputs 4 header lines.
This supports the old use case, and also makes it possible to directly use a $P(k)$ file from CLASS with COLA.

For example:
```sh
CLASSDIR="$HOME/hybrid-bias-cola-emulator/hi_class_public"
COLADIR="$HOME/hybrid-bias-cola-emulator/FML/FML/COLASolver"

mkdir /tmp/test_cola_class_input/
cd /tmp/test_cola_class_input/

cp $CLASSDIR/explanatory.ini .
cp $COLADIR/parameterfile.lua .

$CLASSDIR/class explanatory.ini
sed 's|input/example_power_spectrum_cb_z0.000.txt|output/explanatory00_pk.dat|' parameterfile.lua > parameterfile_class.lua
$COLADIR/nbody parameterfile_class.lua
```
```
...
#=====================================================
# Create initial conditions
#=====================================================
Skipping headerline: # Matter power spectrum P(k) at redshift z=0
Skipping headerline: # for k=1.04206e-05 to 5.30493 h/Mpc,
Skipping headerline: # number of wavenumbers equal to 556
Skipping headerline: #    1:k (h/Mpc)              2:P (Mpc/h)^3        
Line 0 : 1.04206e-05 48.3354 
Line 1 : 2.32697e-05 105.03 
Line 2 : 3.61637e-05 160.801 
Line 3 : 4.91373e-05 216.219 
Line 4 : 6.22254e-05 271.614 
Line 5 : 7.5464e-05 327.236 
Line 6 : 8.88903e-05 383.298 
Line 7 : 0.000102543 440.001 
Line 8 : 0.000116463 497.536 

#=====================================================
# Reading power-spectrum from ascii file [output/explanatory00_pk.dat]
# The P(k) is at the redshift: 0
# Using growth factors we scaled it to redshift: 20
# Found n: 556 lines in file (sample of it below):
#=====================================================
# k (h/Mpc)      P(k,zini)  (Mpc/h)^3    T(k,zini)  (Mpc)^2
1.04206e-05     0.177253        1.19132e+06    
0.00268339      34.4728         1.13778e+06    
0.00948356      80.701          946100         
0.0165519       92.1764         772646         
0.0237718       85.3579         624251         
0.0314024       71.3126         498798         
0.0405931       56.0828         390758         
0.0701943       36.1644         240853         
0.243622        4.96021         48903.6        
0.419948        1.70994         22073          
1.6776          0.0758284       2381.04        
...
```